### PR TITLE
Fix init bug and return values in ClassCornerLWMLM

### DIFF
--- a/mlm/__init__.py
+++ b/mlm/__init__.py
@@ -383,7 +383,7 @@ def class_corner_selection(X, y, radius=None, k_neighbors=16, threshold=9, retur
     Corners = X[corner_idx], y[corner_idx]
 
     if return_costs:
-        Prototypes, Corners, costs
+        return Prototypes, Corners, costs
     return Prototypes, Corners
 
 
@@ -415,7 +415,7 @@ Dealing with Heteroscedasticity in Minimal Learning Machine Framework
 class ClassCornerLWMLMClassifier(LightWeightedMLMClassifier):
 
     def __init__(self, radius=None, k_neighbors=16, threshold=9):
-        super().__init__(self)
+        super().__init__()
 
         self.radius = radius
         self.k_neighbors = k_neighbors


### PR DESCRIPTION
## Summary
- fix `ClassCornerLWMLMClassifier.__init__` call to `super()`
- fix missing return when requesting costs in `class_corner_selection`

## Testing
- `python3 -m py_compile mlm/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68589670c4b88330995eb12a6e275839